### PR TITLE
Upgrade to php 8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ Thumbs.db
 
 # IDE-relative files and folders
 .idea
+
+# phpunit coverage
+.phpunit.cache
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# registry
-[READ-ONLY] Subtree split of the Panda Registry Package
+# Registry Package
+
+> **Note:** [READ-ONLY] Subtree split of the Panda Registry Package
+
+The Registry Package allows you to create Basic and Shared registries that can be used by your application at runtime.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Registry
-[READ-ONLY] Subtree split of the Panda Registry Package
+
+> **[READ-ONLY]** Subtree split of the Panda Registry Package
 
 - [Introduction](#introduction)
 - [Registry Structure](#registry-structure)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# registry
+# Registry
 [READ-ONLY] Subtree split of the Panda Registry Package
+
+- [Introduction](#introduction)
+- [Registry Structure](#registry-structure)
+    - [Normal Registry](#normal-registry)
+    - [Shared Registry](#shared-registry)
+
+## Introduction
+
+Panda Registry is one of the main packages being used across the framework to facilitate the storage of items in key-value pairs.
+
+## Registry Structure 
+
+The current registry implementation is able to store items in runtime and be accessed as long as the application is running.
+
+### Normal Registry
+
+The normal registry implementation is enclosed in a `Registry` object which implements a `RegistryInterface`.
+
+This object can store items as long as the object is alive. When the object is destroyed, all items are lost.
+
+### Shared Registry
+
+The shared registry implementation is common/shared registry that is being created during runtime and resides in memory as long as the application is live and running.
+You can use the SharedRegistry implementation when you need to store statically accessible values without the need of storing the registry object in memory.
+
+At the same time, shared registry consumers can **share** the registry without having to call different objects and turning your code into spaghetti.

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -12,13 +12,13 @@
 namespace Panda\Registry\Tests;
 
 use Panda\Registry\Registry;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RegistryTest
  * @package Panda\Registry\Tests
  */
-class RegistryTest extends PHPUnit_Framework_TestCase
+class RegistryTest extends TestCase
 {
     /**
      * @var Registry
@@ -28,7 +28,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -113,7 +113,6 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers \Panda\Registry\Registry::exists
-     * @throws \PHPUnit_Framework_AssertionFailedError
      */
     public function testExists()
     {

--- a/Tests/SharedRegistryTest.php
+++ b/Tests/SharedRegistryTest.php
@@ -12,13 +12,13 @@
 namespace Panda\Registry\Tests;
 
 use Panda\Registry\SharedRegistry;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SharedRegistryTest
  * @package Panda\Registry\Tests
  */
-class SharedRegistryTest extends PHPUnit_Framework_TestCase
+class SharedRegistryTest extends TestCase
 {
     /**
      * @var SharedRegistry
@@ -28,7 +28,7 @@ class SharedRegistryTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
             "Panda\\Registry\\": ""
         }
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "panda/helpers": "^2.0"
+        "php": "^8.3",
+        "panda/helpers": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~11.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         shortenArraysForExportThreshold="10">
+    <testsuites>
+        <testsuite name="All Tests">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>./</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
### Key updates
- `PHP` from 7.0 to 8.3
- `panda/helpers` from 2.0 to 3.0
- `phpunit/phpunit` from 5.7 to 11.4

### Notable changes
- Added phpunit configuration file