### PR TITLE
Upgrade repository to PHP 8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ Thumbs.db
 
 # IDE-relative files and folders
 .idea
+
+# phpunit coverage
+.phpunit.cache
+coverage.xml

--- a/Tests/RegistryTest.php
+++ b/Tests/RegistryTest.php
@@ -12,13 +12,13 @@
 namespace Panda\Registry\Tests;
 
 use Panda\Registry\Registry;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RegistryTest
  * @package Panda\Registry\Tests
  */
-class RegistryTest extends PHPUnit_Framework_TestCase
+class RegistryTest extends TestCase
 {
     /**
      * @var Registry
@@ -28,7 +28,7 @@ class RegistryTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -113,7 +113,6 @@ class RegistryTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers \Panda\Registry\Registry::exists
-     * @throws \PHPUnit_Framework_AssertionFailedError
      */
     public function testExists()
     {

--- a/Tests/SharedRegistryTest.php
+++ b/Tests/SharedRegistryTest.php
@@ -12,13 +12,13 @@
 namespace Panda\Registry\Tests;
 
 use Panda\Registry\SharedRegistry;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SharedRegistryTest
  * @package Panda\Registry\Tests
  */
-class SharedRegistryTest extends PHPUnit_Framework_TestCase
+class SharedRegistryTest extends TestCase
 {
     /**
      * @var SharedRegistry
@@ -28,7 +28,7 @@ class SharedRegistryTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "panda/helpers": "^2.0"
+        "php": "^8.3",
+        "panda/helpers": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~11.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         shortenArraysForExportThreshold="10">
+    <testsuites>
+        <testsuite name="All Tests">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>./</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
###Key updates
- `PHP` from 7.0 to 8.3
- `panda/helpers` from 2.0 to 3.0
- `phpunit/phpunit` from 5.7 to 11.4

### Notable changes
- Added `phpunit.xml` configuration file. This file is required by the latest `phpunit v11.4` in order to run unit tests.